### PR TITLE
Use invariantSeparatorsPath for resource dirs

### DIFF
--- a/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
+++ b/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
@@ -119,10 +119,12 @@ class ResourcesPlugin : KotlinCompilerPluginSupportPlugin {
         }
 
     private fun getResourceDirs(kotlinCompilation: KotlinCompilation<*>): List<String> {
-        val projectDirPath = kotlinCompilation.target.project.projectDir.path
+        val projectDirPath = kotlinCompilation.target.project.projectDir.invariantSeparatorsPath
         return kotlinCompilation.allKotlinSourceSets.flatMap { sourceSet ->
             // Paths should be relative to the project's directory.
-            sourceSet.resources.srcDirs.map { it.path.removePrefix(projectDirPath).trimStart('/') }
+            sourceSet.resources.srcDirs.map {
+                it.invariantSeparatorsPath.removePrefix(projectDirPath).trimStart('/')
+            }
         }
     }
 
@@ -165,7 +167,7 @@ class ResourcesPlugin : KotlinCompilerPluginSupportPlugin {
             .resolve("karma.config.d")
             .apply { mkdirs() }
             .resolve("proxy-resources.js")
-        
+
         val proxyResourcesTask = tasks.register(taskName) { task ->
             @Suppress("ObjectLiteralToLambda")
             task.doLast(object : Action<Task> {


### PR DESCRIPTION
On Windows the file separator is `\` which results in escaped characters being encoded in the Karma config paths which breaks tests.
e.g. 
```js
config.files.push({
   pattern: __dirname + "/\src\jsTest\resources/**",
   watched: false,
   included: false,
   served: true,
   nocache: false
});
```
This PR changes all resource paths to use `invariantSeparatorsPath` which forces `/` to be used as the separator on all platforms.