### PR TITLE
Open files in binary mode to avoid line conversion issues

### DIFF
--- a/resources-library/src/posixMain/kotlin/Resource.kt
+++ b/resources-library/src/posixMain/kotlin/Resource.kt
@@ -18,7 +18,7 @@ public actual class Resource actual constructor(private val path: String) {
     public actual fun exists(): Boolean = access(path, F_OK) != -1
 
     public actual fun readText(): String = buildString {
-        val file = fopen(path, "rb")
+        val file = fopen(path, "r")
             ?: throw FileReadException("$path: Open failed: ${strerror(posix_errno())}")
         try {
             memScoped {
@@ -33,7 +33,7 @@ public actual class Resource actual constructor(private val path: String) {
     }
 
     public actual fun readBytes(): ByteArray = mutableListOf<Byte>().apply {
-        val file = fopen(path, "r")
+        val file = fopen(path, "rb")
             ?: throw FileReadException("$path: Open failed: ${strerror(posix_errno())}")
         try {
             memScoped {

--- a/resources-library/src/posixMain/kotlin/Resource.kt
+++ b/resources-library/src/posixMain/kotlin/Resource.kt
@@ -18,7 +18,7 @@ public actual class Resource actual constructor(private val path: String) {
     public actual fun exists(): Boolean = access(path, F_OK) != -1
 
     public actual fun readText(): String = buildString {
-        val file = fopen(path, "r")
+        val file = fopen(path, "rb")
             ?: throw FileReadException("$path: Open failed: ${strerror(posix_errno())}")
         try {
             memScoped {


### PR DESCRIPTION
Hey! Thanks for the library its super useful!

I noticed a problem when reading bytes on windows which was causing failures in [projects CI](https://github.com/CharlieTap/chasm/actions/runs/8456310089), when I debugged it I noticed that when calling readBytes on mac I was getting 2 bytes more than on windows for just a few particular files. I patched your library locally with the fix in this PR and it fixed everything. Hopefully we can get a speedy release 🤞🏼 