### PR TITLE
update for kotlin 2.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 useanybrowser = "0.3.0"
-kotlin = "2.0.21"
+kotlin = "2.1.0"
 buildconfig = "5.5.1"
 gradle-publish = "1.3.0"
 nexus-publish = "2.0.0"

--- a/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
+++ b/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
@@ -65,7 +65,7 @@ class ResourcesPlugin : KotlinCompilerPluginSupportPlugin {
                 taskName = getTaskName("copyResources", kotlinCompilation.target.targetName),
                 outputDir = kotlinCompilation.npmProject.dir.map(Directory::getAsFile),
                 mustRunAfterTasks = mutableListOf(kotlinCompilation.processResourcesTaskName).apply {
-                    kotlinCompilation.npmProject.nodeJs.npmInstallTaskProvider.let {
+                    kotlinCompilation.npmProject.nodeJsRoot.npmInstallTaskProvider.let {
                         add(":${it.name}")
                     }
                 },


### PR DESCRIPTION
When using this plugin with kotlin 2.1.0 and a js project, my build fails with

```
... [irrelevant stack]

Caused by: java.lang.NoSuchMethodError: 'org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension org.jetbrains.kotlin.gradle.targets.js.npm.NpmProject.getNodeJs()'
	at com.goncalossilva.resources.ResourcesPlugin.applyToCompilation(ResourcesPlugin.kt:68)
	at org.jetbrains.kotlin.gradle.plugin.SubpluginEnvironment.addSubpluginOptions(SubpluginEnvironment.kt:47)
	at org.jetbrains.kotlin.gradle.plugin.KotlinJsIrSourceSetProcessor$doTargetSpecificProcessing$2.invoke(KotlinJsIrSourceSetProcessor.kt:50)
	at org.jetbrains.kotlin.gradle.plugin.KotlinJsIrSourceSetProcessor$doTargetSpecificProcessing$2.invoke(KotlinJsIrSourceSetProcessor.kt:46)
	at org.jetbrains.kotlin.gradle.utils.WhenEvaluatedKt$whenEvaluated$4.execute(whenEvaluated.kt:48)
	at org.jetbrains.kotlin.gradle.utils.WhenEvaluatedKt$whenEvaluated$4.execute(whenEvaluated.kt:45)
... [snipped]
```

I guess this method was [removed in Kotlin 2.1.0](https://github.com/JetBrains/kotlin/commit/bc02ee8355796cf0cfa41b8ab4ab7da465dc069c); which also causes this PR to fail https://github.com/goncalossilva/kotlinx-resources/pull/138.

It seems like this change is breaking for Kotlin 2.0.x so maybe someone else can find a way to make it work in both.