### PR TITLE
Fix custom resources.srcDir() for non-JVM platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ## [Unreleased]
 
+### Fixed
+
+- Support for resources outside the project directory via `srcDir`
+
 ## [0.11.0] - 2025-12-13
 
 ### Added

--- a/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
+++ b/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
@@ -139,13 +139,9 @@ class ResourcesPlugin : KotlinCompilerPluginSupportPlugin {
         return kotlinCompilation is KotlinJsIrCompilation && kotlinCompilation.target.isBrowserConfigured
     }
 
-    private fun getResourceDirs(kotlinCompilation: KotlinCompilation<*>): List<String> {
-        val projectDirPath = kotlinCompilation.target.project.projectDir.invariantSeparatorsPath
+    private fun getResourceDirs(kotlinCompilation: KotlinCompilation<*>): List<File> {
         return kotlinCompilation.allKotlinSourceSets.flatMap { sourceSet ->
-            // Paths should be relative to the project's directory.
-            sourceSet.resources.srcDirs.filter { it.exists() }.map {
-                it.invariantSeparatorsPath.removePrefix(projectDirPath).trimStart('/')
-            }
+            sourceSet.resources.srcDirs.filter { it.exists() }
         }
     }
 


### PR DESCRIPTION
Closes #161

## Summary

Fixed a bug where resources.srcDir() pointing to directories outside the project would break on JS and Native platforms. The plugin was normalizing paths incorrectly, which caused resource copying to fail for shared resource folders.

The fix returns File objects directly instead of normalized strings, allowing Gradle's Copy task to handle any path correctly.

## Test Plan

- All platform tests pass (JVM, JS Node, JS Browser, Wasm, macOS Native)
- Existing resource loading still works as expected