### PR TITLE
Fix iOS resource task conflicts with Compose Multiplatform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
 - Support for resources outside the project directory via `srcDir`
+
+### Fixed
+
 - Handle all native test binaries instead of just the first
+- Compose Multiplatform compatibility on Apple platforms (#141)
 
 ## [0.11.0] - 2025-12-13
 


### PR DESCRIPTION
Fixes #141

## Summary

- Handle all native test binaries instead of just the first
- Add Compose Multiplatform compatibility for Apple platforms to prevent task dependency conflicts

## Test plan

Ran existing test suite on macOS, iOS simulator, and JVM. All tests pass.