### PR TITLE
Fix ExperimentalWasmDsl opt-in warnings

### DIFF
--- a/resources-library/build.gradle.kts
+++ b/resources-library/build.gradle.kts
@@ -1,3 +1,6 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin

--- a/resources-test/build.gradle.kts
+++ b/resources-test/build.gradle.kts
@@ -1,4 +1,7 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
 import com.goncalossilva.useanybrowser.useAnyBrowser
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin


### PR DESCRIPTION
Add @OptIn annotations to suppress compiler warnings about experimental wasmJs DSL usage in build scripts. This resolves the CI warnings in resources-test and resources-library modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)