### PR TITLE
Catch all Throwable in browser exists() for robustness

### DIFF
--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -60,7 +60,7 @@ public actual class Resource actual constructor(path: String) {
 
         fun exists(): Boolean = try {
             request().isSuccessful()
-        } catch (_: FileReadException) {
+        } catch (_: Throwable) {
             false
         }
 

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -39,7 +39,7 @@ public actual class Resource actual constructor(private val path: String) {
 
         fun exists(): Boolean = try {
             request().isSuccessful()
-        } catch (_: FileReadException) {
+        } catch (_: Throwable) {
             false
         }
 


### PR DESCRIPTION
## Summary
- In browser environments, synchronous XHR may throw JavaScript exceptions that are not properly wrapped in FileReadException by runCatching
- This was causing flaky CI failures on macOS where the doesNotExistNested test would error rather than returning false for non-existent resources
- Widening the catch from FileReadException to Throwable ensures any exception during the XHR request causes exists() to return false

## Test plan
- [x] Ran jsBrowserTest locally - all tests pass
- [x] Ran wasmJsBrowserTest locally - all tests pass
- [x] Ran jvmTest, jsNodeTest, wasmJsNodeTest locally - all tests pass
- [ ] CI should now pass on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)