### PR TITLE
Naming improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Rename `FileReadException` to `ResourceReadException` for naming consistency
+
 ### Added
 
 - Wasm support via `wasmJs` target
@@ -13,7 +17,7 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 - Handle all native test binaries instead of just the first
 - Compose Multiplatform compatibility on iOS ([#141](https://github.com/goncalossilva/kotlinx-resources/issues/141))
-- Wrap XHR errors in `FileReadException` for JS/Wasm browser environments
+- Wrap XHR errors in `ResourceReadException` for JS/Wasm browser environments
 
 ## [0.11.0] - 2025-12-13
 
@@ -108,7 +112,7 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ### Changed
 
-- Throw `FileReadException` when failing to read resources, instead of `RuntimeException`.
+- Throw `ResourceReadException` when failing to read resources, instead of `RuntimeException`.
 - Throw `UnsupportedOperationException` when using unsupported JS runtimes, instead of `RuntimeException`.
 
 ## [0.2.5] - 2023-02-19

--- a/resources-library/src/appleMain/kotlin/Resource.kt
+++ b/resources-library/src/appleMain/kotlin/Resource.kt
@@ -32,7 +32,7 @@ public actual class Resource actual constructor(private val path: String) {
 
     public actual fun readText(charset: Charset): String = memScoped {
         if (absolutePath == null) {
-            throw FileReadException("$path: No such file or directory")
+            throw ResourceReadException("$path: No such file or directory")
         }
         val error = alloc<ObjCObjectVar<NSError?>>()
         // Inlined because NSStringEncoding has different bit widths across Apple platforms.
@@ -45,16 +45,16 @@ public actual class Resource actual constructor(private val path: String) {
             Charset.US_ASCII -> NSASCIIStringEncoding
         }
         NSString.stringWithContentsOfFile(absolutePath, encoding, error.ptr)
-            ?: throw FileReadException("$path: Read failed: ${error.value}")
+            ?: throw ResourceReadException("$path: Read failed: ${error.value}")
     }
 
     public actual fun readBytes(): ByteArray = memScoped {
         if (absolutePath == null) {
-            throw FileReadException("$path: No such file or directory")
+            throw ResourceReadException("$path: No such file or directory")
         }
         val error = alloc<ObjCObjectVar<NSError?>>()
         val data = NSData.dataWithContentsOfFile(absolutePath, NSDataReadingUncached, error.ptr)
-        val bytes = data?.bytes ?: throw FileReadException("$path: Read failed: ${error.value}")
+        val bytes = data?.bytes ?: throw ResourceReadException("$path: Read failed: ${error.value}")
         bytes.readBytes(data.length.toInt())
     }
 }

--- a/resources-library/src/commonMain/kotlin/ByteArrayExt.kt
+++ b/resources-library/src/commonMain/kotlin/ByteArrayExt.kt
@@ -68,4 +68,3 @@ internal fun ByteArray.decodeUtf16(): String {
         }
     }
 }
-

--- a/resources-library/src/commonMain/kotlin/Resource.kt
+++ b/resources-library/src/commonMain/kotlin/Resource.kt
@@ -16,14 +16,14 @@ public expect class Resource(path: String) {
      * Returns the resource's content as a string decoded using the specified [charset].
      *
      * @param charset The character encoding to use. Defaults to [Charsets.UTF_8].
-     * @throws FileReadException when the resource doesn't exist or can't be read.
+     * @throws ResourceReadException when the resource doesn't exist or can't be read.
      */
     public fun readText(charset: Charset = Charsets.UTF_8): String
 
     /**
      * Returns the resource's content as a byte array.
      *
-     * @throws FileReadException when the resource doesn't exist or can't be read.
+     * @throws ResourceReadException when the resource doesn't exist or can't be read.
      */
     public fun readBytes(): ByteArray
 }

--- a/resources-library/src/commonMain/kotlin/ResourceReadException.kt
+++ b/resources-library/src/commonMain/kotlin/ResourceReadException.kt
@@ -1,6 +1,6 @@
 package com.goncalossilva.resources
 
-public class FileReadException : RuntimeException {
+public class ResourceReadException : RuntimeException {
     public constructor() : super()
     public constructor(message: String?) : super(message)
     public constructor(message: String?, cause: Throwable?) : super(message, cause)

--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -55,7 +55,7 @@ public actual class Resource actual constructor(path: String) {
                 send()
             }
         }.getOrElse { cause ->
-            throw FileReadException("$path: Request failed", cause)
+            throw ResourceReadException("$path: Request failed", cause)
         }
 
         @Suppress("MagicNumber")
@@ -79,7 +79,7 @@ public actual class Resource actual constructor(path: String) {
                 val response = request.responseText
                 ByteArray(response.length) { response[it].code.toUByte().toByte() }
             } else {
-                throw FileReadException("$path: Read failed (status=${request.status})")
+                throw ResourceReadException("$path: Read failed (status=${request.status})")
             }
         }
 
@@ -135,7 +135,7 @@ public actual class Resource actual constructor(path: String) {
                 runCatching {
                     fs.readFileSync(path, nodeEncoding) as String
                 }.getOrElse { cause ->
-                    throw FileReadException("$path: Read failed", cause)
+                    throw ResourceReadException("$path: Read failed", cause)
                 }
             } else {
                 // Node doesn't support this encoding natively, decode manually.
@@ -143,7 +143,7 @@ public actual class Resource actual constructor(path: String) {
                     val buffer = fs.readFileSync(path).unsafeCast<Uint8Array>()
                     Int8Array(buffer.buffer, buffer.byteOffset, buffer.length).unsafeCast<ByteArray>()
                 }.getOrElse { cause ->
-                    throw FileReadException("$path: Read failed", cause)
+                    throw ResourceReadException("$path: Read failed", cause)
                 }
                 when (charset) {
                     Charset.UTF_16 -> bytes.decodeUtf16()
@@ -157,7 +157,7 @@ public actual class Resource actual constructor(path: String) {
             val buffer = fs.readFileSync(path).unsafeCast<Uint8Array>()
             Int8Array(buffer.buffer, buffer.byteOffset, buffer.length).unsafeCast<ByteArray>()
         }.getOrElse { cause ->
-            throw FileReadException("$path: Read failed", cause)
+            throw ResourceReadException("$path: Read failed", cause)
         }
     }
 }

--- a/resources-library/src/jvmMain/kotlin/Resource.kt
+++ b/resources-library/src/jvmMain/kotlin/Resource.kt
@@ -15,13 +15,13 @@ public actual class Resource actual constructor(private val path: String) {
     public actual fun readText(charset: Charset): String = runCatching {
         resourceFile.readText(charset.toJavaCharset())
     }.getOrElse { cause ->
-        throw FileReadException("$path: No such file or directory", cause)
+        throw ResourceReadException("$path: No such file or directory", cause)
     }
 
     public actual fun readBytes(): ByteArray = runCatching {
         resourceFile.readBytes()
     }.getOrElse { cause ->
-        throw FileReadException("$path: No such file or directory", cause)
+        throw ResourceReadException("$path: No such file or directory", cause)
     }
 }
 

--- a/resources-library/src/posixMain/kotlin/Resource.kt
+++ b/resources-library/src/posixMain/kotlin/Resource.kt
@@ -22,7 +22,7 @@ public actual class Resource actual constructor(private val path: String) {
 
     public actual fun readBytes(): ByteArray = mutableListOf<Byte>().apply {
         val file = fopen(path, "rb")
-            ?: throw FileReadException("$path: Open failed: ${strerror(posix_errno())}")
+            ?: throw ResourceReadException("$path: Open failed: ${strerror(posix_errno())}")
         try {
             memScoped {
                 val buffer = allocArray<ByteVar>(BUFFER_SIZE)

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -55,7 +55,7 @@ public actual class Resource actual constructor(private val path: String) {
                 val length = jsStringLength(response)
                 ByteArray(length) { (jsCharCodeAt(response, it) and 0xFF).toByte() }
             } else {
-                throw FileReadException("$errorPrefix: Read failed (status=${request.status})")
+                throw ResourceReadException("$errorPrefix: Read failed (status=${request.status})")
             }
         }
 
@@ -69,7 +69,7 @@ public actual class Resource actual constructor(private val path: String) {
                 send()
             }
         }.getOrElse { cause ->
-            throw FileReadException("$errorPrefix: Request failed", cause)
+            throw ResourceReadException("$errorPrefix: Request failed", cause)
         }
 
         @Suppress("MagicNumber")
@@ -104,14 +104,14 @@ public actual class Resource actual constructor(private val path: String) {
                 runCatching {
                     nodeReadFileSync(jsPath, nodeEncoding.toJsString()).toString()
                 }.getOrElse { cause ->
-                    throw FileReadException("$errorPrefix: Read failed", cause)
+                    throw ResourceReadException("$errorPrefix: Read failed", cause)
                 }
             } else {
                 // Node doesn't support this encoding natively, decode manually.
                 val bytes = runCatching {
                     nodeReadFileSyncBytes(jsPath).toByteArray()
                 }.getOrElse { cause ->
-                    throw FileReadException("$errorPrefix: Read failed", cause)
+                    throw ResourceReadException("$errorPrefix: Read failed", cause)
                 }
                 when (charset) {
                     Charset.UTF_16 -> bytes.decodeUtf16()
@@ -124,7 +124,7 @@ public actual class Resource actual constructor(private val path: String) {
         fun readBytes(): ByteArray = runCatching {
             nodeReadFileSyncBytes(jsPath).toByteArray()
         }.getOrElse { cause ->
-            throw FileReadException("$errorPrefix: Read failed", cause)
+            throw ResourceReadException("$errorPrefix: Read failed", cause)
         }
 
         private fun NodeBuffer.toByteArray(): ByteArray = ByteArray(length) { this[it] }

--- a/resources-test/src/commonTest/kotlin/ResourceTest.kt
+++ b/resources-test/src/commonTest/kotlin/ResourceTest.kt
@@ -43,17 +43,17 @@ class ResourceTest {
 
     @Test
     fun readTextRootThrowsWhenNotFound() {
-        assertFailsWith<FileReadException> {
+        assertFailsWith<ResourceReadException> {
             Resource("404.json").readText()
         }
     }
 
     @Test
     fun readTextNestedThrowsWhenNotFound() {
-        assertFailsWith<FileReadException> {
+        assertFailsWith<ResourceReadException> {
             Resource("a/404.json").readText()
         }
-        assertFailsWith<FileReadException> {
+        assertFailsWith<ResourceReadException> {
             Resource("a/folder/404.json").readText()
         }
     }
@@ -71,17 +71,17 @@ class ResourceTest {
 
     @Test
     fun readBytesRootThrowsWhenNotFound() {
-        assertFailsWith<FileReadException> {
+        assertFailsWith<ResourceReadException> {
             Resource("404.gz").readBytes()
         }
     }
 
     @Test
     fun readBytesNestedThrowsWhenNotFound() {
-        assertFailsWith<FileReadException> {
+        assertFailsWith<ResourceReadException> {
             Resource("a/404.gz").readBytes()
         }
-        assertFailsWith<FileReadException> {
+        assertFailsWith<ResourceReadException> {
             Resource("a/folder/404.gz").readBytes()
         }
     }


### PR DESCRIPTION
## Summary

- Rename CharsetDecoding.kt to ByteArrayExt.kt for clarity
- Refactor decodeUtf16() to use a Pair as the when subject instead of compound conditions
- Rename FileReadException to ResourceReadException for naming consistency across the API

## Test plan

- [x] Existing tests pass with the renamed exception
- [x] File rename preserves git history
- [x] All references updated across all platforms (JVM, JS, Wasm, Apple, POSIX)