### PR TITLE
Remove redundant -Xexpect-actual-classes compiler flag

### DIFF
--- a/resources-library/build.gradle.kts
+++ b/resources-library/build.gradle.kts
@@ -7,8 +7,6 @@ import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnLockMismatchReport
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootEnvSpec
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
 
@@ -83,12 +81,6 @@ kotlin {
         }
     }
 
-    compilerOptions {
-        freeCompilerArgs.add("-Xexpect-actual-classes")
-    }
-}
-
-tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }


### PR DESCRIPTION
## Summary
- Removes the duplicate `-Xexpect-actual-classes` compiler flag configuration
- The flag was being added in both the `kotlin { compilerOptions }` block and `tasks.withType<KotlinCompile>()` block
- Keeps only the former as it covers all compilation tasks

Fixes #229

## Test plan
- [x] Verify Gradle configuration parses correctly with `--dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)