### PR TITLE
Add changelog entry for charset support in readText()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 ### Changed
 
 - **BREAKING:** Rename `FileReadException` to `ResourceReadException` for naming consistency
+- **BREAKING:** Add charset parameter to `readText()` with UTF-8 as default. Supported charsets: UTF-8, UTF-16, UTF-16BE, UTF-16LE, ISO-8859-1, and US-ASCII.
 
 ### Added
 


### PR DESCRIPTION
Documents the breaking change introduced in PR #218 that adds charset parameter support to `readText()` with UTF-8 as default, including the six supported character encodings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)