### PR TITLE
Replace deprecated actions/create-release with softprops/action-gh-release

### DIFF
--- a/.github/workflows/build-publish-release.yml
+++ b/.github/workflows/build-publish-release.yml
@@ -68,11 +68,10 @@ jobs:
   release:
     needs: [publish-plugin, publish-library]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          generate_release_notes: true


### PR DESCRIPTION
Replaces the archived `actions/create-release@v1` action with the actively maintained `softprops/action-gh-release@v2`. The old action uses the deprecated `set-output` command which will be disabled soon. The new action also provides automatic release notes generation via the `generate_release_notes` flag.

This fixes the GitHub Actions deprecation warnings from the build pipeline.