### PR TITLE
Rename platformResourceOverload to platformResourceOverride

### DIFF
--- a/resources-test/src/appleTest/kotlin/AppleResourceTest.kt
+++ b/resources-test/src/appleTest/kotlin/AppleResourceTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class AppleResourceTest {
 
     @Test
-    fun platformResourceOverload() {
+    fun platformResourceOverride() {
         assertTrue(Resource("platform_resource.txt").exists())
         assertEquals("apple", Resource("platform_resource.txt").readText())
     }

--- a/resources-test/src/jsTest/kotlin/JsResourceTest.kt
+++ b/resources-test/src/jsTest/kotlin/JsResourceTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class JsResourceTest {
 
     @Test
-    fun platformResourceOverload() {
+    fun platformResourceOverride() {
         assertTrue(Resource("platform_resource.txt").exists())
         assertEquals("js", Resource("platform_resource.txt").readText())
     }

--- a/resources-test/src/jvmTest/kotlin/JvmResourceTest.kt
+++ b/resources-test/src/jvmTest/kotlin/JvmResourceTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class JvmResourceTest {
 
     @Test
-    fun platformResourceOverload() {
+    fun platformResourceOverride() {
         assertTrue(Resource("platform_resource.txt").exists())
         assertEquals("jvm", Resource("platform_resource.txt").readText())
     }

--- a/resources-test/src/linuxTest/kotlin/LinuxResourceTest.kt
+++ b/resources-test/src/linuxTest/kotlin/LinuxResourceTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class LinuxResourceTest {
 
     @Test
-    fun platformResourceOverload() {
+    fun platformResourceOverride() {
         assertTrue(Resource("platform_resource.txt").exists())
         assertEquals("linux", Resource("platform_resource.txt").readText())
     }

--- a/resources-test/src/wasmJsTest/kotlin/WasmJsResourceTest.kt
+++ b/resources-test/src/wasmJsTest/kotlin/WasmJsResourceTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class WasmJsResourceTest {
 
     @Test
-    fun platformResourceOverload() {
+    fun platformResourceOverride() {
         assertTrue(Resource("platform_resource.txt").exists())
         assertEquals("wasmjs", Resource("platform_resource.txt").readText())
     }


### PR DESCRIPTION
Fixes function naming typo across all platform test files.

"Overload" was a mistake; the function overrides platform resources, not overloading them.