### PR TITLE
Disable MagicNumber rule in Detekt

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,3 +1,7 @@
 naming:
     InvalidPackageDeclaration:
         rootPackage: 'com.goncalossilva.resources'
+
+style:
+    MagicNumber:
+        active: false

--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -58,7 +58,6 @@ public actual class Resource actual constructor(path: String) {
             throw ResourceReadException("$path: Request failed", cause)
         }
 
-        @Suppress("MagicNumber")
         private fun XMLHttpRequest.isSuccessful() = status in 200..299
 
         fun exists(): Boolean = runCatching {

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -75,7 +75,6 @@ public actual class Resource actual constructor(private val path: String) {
             throw ResourceReadException("$errorPrefix: Request failed", cause)
         }
 
-        @Suppress("MagicNumber")
         private fun XMLHttpRequest.isSuccessful() = status in 200..299
 
         private fun ByteArray.decodeWith(charset: Charset): String = when (charset) {

--- a/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
+++ b/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
@@ -442,7 +442,6 @@ class ResourcesPlugin : KotlinCompilerPluginSupportPlugin {
                         val content = mjsFile.readText()
                         if (dotMappingPattern.containsMatchIn(content)) continue // Already has '.' mapping
 
-                        @Suppress("MagicNumber")
                         val patched = if (existingPreopensPattern.containsMatchIn(content)) {
                             // Merge '.' mapping into existing preopens object.
                             existingPreopensPattern.replace(content) { match ->


### PR DESCRIPTION
Disables the MagicNumber rule in Detekt configuration and removes the associated suppressions. This rule was generating noise without providing significant value for this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)