### PR TITLE
Rename platformResourceOverload in WasmWasiResourceTest

### DIFF
--- a/resources-test/src/wasmWasiTest/kotlin/com/goncalossilva/resources/WasmWasiResourceTest.kt
+++ b/resources-test/src/wasmWasiTest/kotlin/com/goncalossilva/resources/WasmWasiResourceTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class WasmWasiResourceTest {
 
     @Test
-    fun platformResourceOverload() {
+    fun platformResourceOverride() {
         assertTrue(Resource("platform_resource.txt").exists())
         assertEquals("wasmwasi", Resource("platform_resource.txt").readText())
     }


### PR DESCRIPTION
Follow-up to #240 - missed the WasmWasi test file in the original rename.