### PR TITLE
Fix flaky browser tests in ChromeHeadless

### DIFF
--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -58,7 +58,8 @@ public actual class Resource actual constructor(path: String) {
             throw ResourceReadException("$path: Request failed", cause)
         }
 
-        private fun XMLHttpRequest.isSuccessful() = status in 200..299
+        private fun XMLHttpRequest.isSuccessful() =
+            readyState == 4.toShort() && status in 200..299
 
         fun exists(): Boolean = runCatching {
             request(method = "HEAD").isSuccessful()

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -75,7 +75,7 @@ public actual class Resource actual constructor(private val path: String) {
             throw ResourceReadException("$errorPrefix: Request failed", cause)
         }
 
-        private fun XMLHttpRequest.isSuccessful() = status in 200..299
+        private fun XMLHttpRequest.isSuccessful() = readyState == 4 && status in 200..299
 
         private fun ByteArray.decodeWith(charset: Charset): String = when (charset) {
             Charset.UTF_8 -> decodeWithTextDecoder("utf-8")
@@ -157,6 +157,7 @@ private external class XMLHttpRequest : JsAny {
     fun open(method: JsString, url: JsString, async: Boolean)
     fun send()
     fun overrideMimeType(mimeType: JsString)
+    val readyState: Int
     val status: Int
     val statusText: JsString
     val responseText: JsString


### PR DESCRIPTION
Fixes intermittent test failures in ChromeHeadless by checking XMLHttpRequest readyState before accessing status.

The synchronous XMLHttpRequest in ChromeHeadless can complete in unexpected states. Accessing status without first verifying readyState == 4 (DONE) may throw JavaScript exceptions.

This adds a defensive check: readyState == 4 && status in 200..299

Fixes #234