### PR TITLE
Use /base/ paths under Karma

### DIFF
--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -9,6 +9,8 @@ private val IS_BROWSER: Boolean = js(IS_BROWSER_JS_CHECK)
 
 private val IS_NODE: Boolean = js(IS_NODE_JS_CHECK)
 
+private val IS_KARMA: Boolean = js(IS_KARMA_JS_CHECK)
+
 private external class TextDecoder(encoding: String = definedExternally) {
     fun decode(input: Uint8Array): String
 }
@@ -45,12 +47,15 @@ public actual class Resource actual constructor(path: String) {
      * Resource access via XMLHttpRequest (for browser environments).
      */
     private class ResourceBrowser(private val path: String) {
+        private val requestUrl: String =
+            if (IS_KARMA && !path.startsWith("/") && !path.contains("://")) "/base/$path" else path
+
         private fun request(
             method: String = "GET",
             config: (XMLHttpRequest.() -> Unit)? = null,
         ): XMLHttpRequest = runCatching {
             XMLHttpRequest().apply {
-                open(method, path, false)
+                open(method, requestUrl, false)
                 config?.invoke(this)
                 send()
             }

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -37,7 +37,8 @@ public actual class Resource actual constructor(private val path: String) {
      * Resource access via XMLHttpRequest (for browser environments).
      */
     private class ResourceBrowser(path: String) {
-        private val jsPath: JsString = path.toJsString()
+        private val jsPath: JsString =
+            (if (IS_KARMA && !path.startsWith("/") && !path.contains("://")) "/base/$path" else path).toJsString()
         private val errorPrefix: String = path
 
         fun exists(): Boolean = runCatching {
@@ -139,6 +140,8 @@ public actual class Resource actual constructor(private val path: String) {
 private val IS_BROWSER: Boolean = js(IS_BROWSER_JS_CHECK)
 
 private val IS_NODE: Boolean = js(IS_NODE_JS_CHECK)
+
+private val IS_KARMA: Boolean = js(IS_KARMA_JS_CHECK)
 
 private fun nodeExistsSync(path: JsString): Boolean = js("require('fs').existsSync(path)")
 

--- a/resources-library/src/webMain/kotlin/RuntimeDetection.kt
+++ b/resources-library/src/webMain/kotlin/RuntimeDetection.kt
@@ -6,3 +6,5 @@ internal const val IS_BROWSER_JS_CHECK: String =
 
 internal const val IS_NODE_JS_CHECK: String =
     "typeof process !== 'undefined' && process.versions != null && process.versions.node != null"
+
+internal const val IS_KARMA_JS_CHECK: String = "typeof __karma__ !== 'undefined'"


### PR DESCRIPTION
Avoids relying on Karma proxy rewrites by requesting browser resources via /base/ when running under Karma (detected via __karma__).\n\nFixes #234.