### PR TITLE
Revert XHR readyState guard

### DIFF
--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -53,7 +53,6 @@ public actual class Resource actual constructor(path: String) {
                 open(method, path, false)
                 config?.invoke(this)
                 send()
-                check(readyState == XMLHttpRequest.DONE) { "Request incomplete" }
             }
         }.getOrElse { cause ->
             throw ResourceReadException("$path: Request failed", cause)

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -70,7 +70,6 @@ public actual class Resource actual constructor(private val path: String) {
                 open(method.toJsString(), jsPath, false)
                 config?.invoke(this)
                 send()
-                check(readyState == XMLHttpRequest.DONE) { "Request incomplete" }
             }
         }.getOrElse { cause ->
             throw ResourceReadException("$errorPrefix: Request failed", cause)
@@ -158,14 +157,9 @@ private external class XMLHttpRequest : JsAny {
     fun open(method: JsString, url: JsString, async: Boolean)
     fun send()
     fun overrideMimeType(mimeType: JsString)
-    val readyState: Int
     val status: Int
     val statusText: JsString
     val responseText: JsString
-
-    companion object {
-        val DONE: Int
-    }
 }
 
 private fun createXMLHttpRequest(): XMLHttpRequest = js("new XMLHttpRequest()")


### PR DESCRIPTION
Reverts #246 (XHR readyState guard). This should be unnecessary now that the Karma urlRoot proxy fix is in place. Running CI 20x to confirm stability without the guard.