### PR TITLE
Fix JVM resources with spaces in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix JVM resource loading when filenames contain spaces or other URL-special characters. ([#272](https://github.com/goncalossilva/kotlinx-resources/issues/272))
+
 ## [0.14.4] - 2026-01-28
 
 ### Fixed

--- a/resources-library/src/jvmMain/kotlin/Resource.kt
+++ b/resources-library/src/jvmMain/kotlin/Resource.kt
@@ -1,25 +1,25 @@
 package com.goncalossilva.resources
 
-import java.io.File
+import java.io.InputStream
 
 public actual class Resource actual constructor(private val path: String) {
 
-    private val resourcePath: String?
-        get() = Resource::class.java.classLoader.getResource(path)?.path
+    private val resource
+        get() = Resource::class.java.classLoader.getResource(path)
 
-    private val resourceFile: File
-        get() = File(resourcePath)
+    private val resourceStream: InputStream
+        get() = Resource::class.java.classLoader.getResourceAsStream(path)!!
 
-    public actual fun exists(): Boolean = resourcePath != null
+    public actual fun exists(): Boolean = resource != null
 
     public actual fun readText(charset: Charset): String = runCatching {
-        resourceFile.readText(charset.toJavaCharset())
+        resourceStream.use { it.readBytes().toString(charset.toJavaCharset()) }
     }.getOrElse { cause ->
         throw ResourceReadException("$path: No such file or directory", cause)
     }
 
     public actual fun readBytes(): ByteArray = runCatching {
-        resourceFile.readBytes()
+        resourceStream.use { it.readBytes() }
     }.getOrElse { cause ->
         throw ResourceReadException("$path: No such file or directory", cause)
     }

--- a/resources-test/src/commonTest/kotlin/ResourceTest.kt
+++ b/resources-test/src/commonTest/kotlin/ResourceTest.kt
@@ -128,6 +128,11 @@ class ResourceTest {
         assertEquals("H\u00E9llo", Resource("charset-utf8.txt").readText())
     }
 
+    @Test
+    fun readsResourceWithSpaces() {
+        assertEquals("hello", Resource("file with spaces.txt").readText().trim())
+    }
+
     companion object {
         const val JSON: String = "{}\n"
         val GZIP: ByteArray = byteArrayOf(

--- a/resources-test/src/jsTest/kotlin/JsResourceTest.kt
+++ b/resources-test/src/jsTest/kotlin/JsResourceTest.kt
@@ -12,8 +12,4 @@ class JsResourceTest {
         assertEquals("js", Resource("platform_resource.txt").readText())
     }
 
-    @Test
-    fun readsResourceWithSpaces() {
-        assertEquals("hello", Resource("file with spaces.txt").readText().trim())
-    }
 }

--- a/resources-test/src/jvmTest/kotlin/JvmResourceTest.kt
+++ b/resources-test/src/jvmTest/kotlin/JvmResourceTest.kt
@@ -11,4 +11,5 @@ class JvmResourceTest {
         assertTrue(Resource("platform_resource.txt").exists())
         assertEquals("jvm", Resource("platform_resource.txt").readText())
     }
+
 }

--- a/resources-test/src/wasmJsTest/kotlin/WasmJsResourceTest.kt
+++ b/resources-test/src/wasmJsTest/kotlin/WasmJsResourceTest.kt
@@ -12,8 +12,4 @@ class WasmJsResourceTest {
         assertEquals("wasmjs", Resource("platform_resource.txt").readText())
     }
 
-    @Test
-    fun readsResourceWithSpaces() {
-        assertEquals("hello", Resource("file with spaces.txt").readText().trim())
-    }
 }


### PR DESCRIPTION
`ClassLoader.getResource(path).path` returns URL-encoded paths where spaces become `%20`, causing `FileNotFoundException` when passed to `java.io.File`. Switch to `getResourceAsStream()` which resolves resources internally and also handles JAR-packaged resources correctly.

Moves the spaces-in-path test from platform-specific (JS, wasmJs) to `commonTest` so it covers all platforms.

Partially fixes #272.