### PR TITLE
Fix iOS task dependency with Compose Multiplatform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 ### Fixed
 
 - Fix JVM resource loading when filenames contain spaces or other URL-special characters. ([#272](https://github.com/goncalossilva/kotlinx-resources/issues/272))
+- Fix iOS task dependency conflict with Compose Multiplatform resource assembly. ([#272](https://github.com/goncalossilva/kotlinx-resources/issues/272))
 
 ## [0.14.4] - 2026-01-28
 

--- a/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
+++ b/resources-plugin/src/main/kotlin/ResourcesPlugin.kt
@@ -112,13 +112,14 @@ class ResourcesPlugin : KotlinCompilerPluginSupportPlugin {
             )
 
             if (isIosCompilation(compilation)) {
-                // HACK: Avoid task dependency conflicts with Compose Multiplatform on iOS.
+                // Declare a dependency on Compose Multiplatform resource assembly tasks on iOS,
+                // since our copy task reads from resource dirs that include Compose-generated outputs.
                 val composeResourceTasks = project.tasks.matching { task ->
                     task.name.startsWith("assemble") &&
                         task.name.contains(target.targetName) &&
                         task.name.endsWith("TestResources")
                 }
-                copyResourcesTask.configure { it.mustRunAfter(composeResourceTasks) }
+                copyResourcesTask.configure { it.dependsOn(composeResourceTasks) }
             } else if (!isAppleCompilation(compilation)) {
                 project.tasks.withType(KotlinNativeTest::class.java) { testTask ->
                     testTask.workingDir = binary.outputDirectory.absolutePath


### PR DESCRIPTION
Change `mustRunAfter` to `dependsOn` for Compose resource assembly tasks on iOS. Gradle requires an explicit dependency since our copy task reads from resource dirs that include Compose-generated outputs. When Compose isn't present, the task collection is empty and `dependsOn` is a no-op.

Partially fixes #272.