### PR TITLE
Make Resource.path public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ## [Unreleased]
 
+### Added
+
+- Make `Resource.path` public. ([#271](https://github.com/goncalossilva/kotlinx-resources/issues/271))
+
 ### Fixed
 
 - Fix JVM resource loading when filenames contain spaces or other URL-special characters. ([#272](https://github.com/goncalossilva/kotlinx-resources/issues/272))

--- a/resources-library/src/androidMain/kotlin/com/goncalossilva/resources/Resource.kt
+++ b/resources-library/src/androidMain/kotlin/com/goncalossilva/resources/Resource.kt
@@ -11,7 +11,7 @@ import java.io.IOException
  *
  * Assets are tried first (when running in an instrumentation context), falling back to ClassLoader.
  */
-public actual class Resource actual constructor(private val path: String) {
+public actual class Resource actual constructor(public actual val path: String) {
     /**
      * Normalized path with leading '/' stripped.
      *

--- a/resources-library/src/appleMain/kotlin/Resource.kt
+++ b/resources-library/src/appleMain/kotlin/Resource.kt
@@ -22,7 +22,7 @@ import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.stringWithContentsOfFile
 
 @OptIn(UnsafeNumber::class)
-public actual class Resource actual constructor(private val path: String) {
+public actual class Resource actual constructor(public actual val path: String) {
     private val absolutePath = NSBundle.mainBundle.pathForResource(
         path.substringBeforeLast("."),
         path.substringAfterLast(".")

--- a/resources-library/src/commonMain/kotlin/Resource.kt
+++ b/resources-library/src/commonMain/kotlin/Resource.kt
@@ -9,6 +9,11 @@ package com.goncalossilva.resources
  */
 public expect class Resource(path: String) {
     /**
+     * The resource path, as provided to the constructor.
+     */
+    public val path: String
+
+    /**
      * Returns true when the resource exists, false when it doesn't.
      */
     public fun exists(): Boolean

--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -19,7 +19,7 @@ private external class TextDecoder(encoding: String = definedExternally) {
  *
  * Workaround inspired by Ktor: https://github.com/ktorio/ktor/blob/b8f18e40baabf9756a16843d6cbd80bff6f006c6/ktor-utils/js/src/io/ktor/util/PlatformUtilsJs.kt#L9-L15
  */
-public actual class Resource actual constructor(path: String) {
+public actual class Resource actual constructor(public actual val path: String) {
     private val resourceBrowser: ResourceBrowser by lazy { ResourceBrowser(path) }
     private val resourceNode: ResourceNode by lazy { ResourceNode(path) }
 

--- a/resources-library/src/jvmMain/kotlin/Resource.kt
+++ b/resources-library/src/jvmMain/kotlin/Resource.kt
@@ -2,7 +2,7 @@ package com.goncalossilva.resources
 
 import java.io.InputStream
 
-public actual class Resource actual constructor(private val path: String) {
+public actual class Resource actual constructor(public actual val path: String) {
 
     private val resource
         get() = Resource::class.java.classLoader.getResource(path)

--- a/resources-library/src/posixMain/kotlin/Resource.kt
+++ b/resources-library/src/posixMain/kotlin/Resource.kt
@@ -12,7 +12,7 @@ import platform.posix.fread
 import platform.posix.posix_errno
 import platform.posix.strerror
 
-public actual class Resource actual constructor(private val path: String) {
+public actual class Resource actual constructor(public actual val path: String) {
     public actual fun exists(): Boolean = access(path, F_OK) != -1
 
     public actual fun readText(charset: Charset): String {

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -11,7 +11,7 @@ import kotlin.js.toJsString
  * It's impossible to separate browser/node JS runtimes, as they can't be published separately.
  * See: https://youtrack.jetbrains.com/issue/KT-47038
  */
-public actual class Resource actual constructor(private val path: String) {
+public actual class Resource actual constructor(public actual val path: String) {
     private val resourceBrowser: ResourceBrowser by lazy { ResourceBrowser(path) }
     private val resourceNode: ResourceNode by lazy { ResourceNode(path) }
 

--- a/resources-library/src/wasmWasiMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmWasiMain/kotlin/Resource.kt
@@ -62,7 +62,7 @@ private external fun wasiPathFilestatGet(
 // Buffer size balances memory usage with I/O efficiency for typical resource files.
 private const val BUFFER_SIZE = 8 * 1024
 
-public actual class Resource actual constructor(private val path: String) {
+public actual class Resource actual constructor(public actual val path: String) {
     public actual fun exists(): Boolean = withScopedMemoryAllocator { allocator ->
         val pathBytes = path.encodeToByteArray()
         val pathPtr = allocator.writeBytes(pathBytes)

--- a/resources-test/src/commonTest/kotlin/ResourceTest.kt
+++ b/resources-test/src/commonTest/kotlin/ResourceTest.kt
@@ -133,6 +133,13 @@ class ResourceTest {
         assertEquals("hello", Resource("file with spaces.txt").readText().trim())
     }
 
+    @Test
+    fun pathReturnsOriginalValue() {
+        assertEquals("302.json", Resource("302.json").path)
+        assertEquals("a/302.json", Resource("a/302.json").path)
+        assertEquals("file with spaces.txt", Resource("file with spaces.txt").path)
+    }
+
     companion object {
         const val JSON: String = "{}\n"
         val GZIP: ByteArray = byteArrayOf(


### PR DESCRIPTION
Expose the `path` property so callers can use it for logging, diagnostics, or any other purpose.

Closes #271.