### PR TITLE
Add IDE completion for resource paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ## [Unreleased]
 
+### Added
+
+- Add IDE completion and navigation for resource paths. ([#64](https://github.com/goncalossilva/kotlinx-resources/issues/64))
+
 ### Changed
 
 - Require Java 17 or newer to run the Gradle plugin. ([#308](https://github.com/goncalossilva/kotlinx-resources/pull/308))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ android-sdk-compile = "36"
 android-sdk-min = "21"
 androidx-test-core = "1.7.0"
 androidx-test-runner = "1.7.0"
+jetbrains-annotations = "26.1.0"
 useanybrowser = "0.5.0"
 buildconfig = "6.0.10"
 detekt = "1.23.8"
@@ -17,6 +18,7 @@ yarn = "1.22.22"
 [libraries]
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/resources-library/build.gradle.kts
+++ b/resources-library/build.gradle.kts
@@ -82,7 +82,11 @@ kotlin {
             languageSettings.optIn("kotlinx.cinterop.BetaInteropApi")
         }
 
-        val commonMain by getting
+        val commonMain by getting {
+            dependencies {
+                api(libs.jetbrains.annotations)
+            }
+        }
         val jsMain by getting
         val wasmJsMain by getting
         val wasmWasiMain by getting {

--- a/resources-library/src/androidMain/kotlin/com/goncalossilva/resources/Resource.kt
+++ b/resources-library/src/androidMain/kotlin/com/goncalossilva/resources/Resource.kt
@@ -3,6 +3,7 @@ package com.goncalossilva.resources
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import java.io.IOException
+import org.intellij.lang.annotations.Language
 
 /**
  * Android resource implementation supporting two execution contexts:
@@ -11,7 +12,9 @@ import java.io.IOException
  *
  * Assets are tried first (when running in an instrumentation context), falling back to ClassLoader.
  */
-public actual class Resource actual constructor(public actual val path: String) {
+public actual class Resource actual constructor(
+    @Language("file-reference") public actual val path: String
+) {
     /**
      * Normalized path with leading '/' stripped.
      *

--- a/resources-library/src/appleMain/kotlin/Resource.kt
+++ b/resources-library/src/appleMain/kotlin/Resource.kt
@@ -7,6 +7,7 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.readBytes
 import kotlinx.cinterop.value
+import org.intellij.lang.annotations.Language
 import platform.Foundation.NSASCIIStringEncoding
 import platform.Foundation.NSBundle
 import platform.Foundation.NSData
@@ -22,7 +23,9 @@ import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.stringWithContentsOfFile
 
 @OptIn(UnsafeNumber::class)
-public actual class Resource actual constructor(public actual val path: String) {
+public actual class Resource actual constructor(
+    @Language("file-reference") public actual val path: String
+) {
     private val absolutePath = NSBundle.mainBundle.pathForResource(
         path.substringBeforeLast("."),
         path.substringAfterLast(".")

--- a/resources-library/src/commonMain/kotlin/Resource.kt
+++ b/resources-library/src/commonMain/kotlin/Resource.kt
@@ -1,5 +1,7 @@
 package com.goncalossilva.resources
 
+import org.intellij.lang.annotations.Language
+
 /**
  * Provides access to resource on [path].
  *
@@ -7,7 +9,9 @@ package com.goncalossilva.resources
  * `Resource("some/optional/folders/file.txt")` for a file located at
  * `src/commonTest/resources/some/optional/folders/file.txt`.
  */
-public expect class Resource(path: String) {
+public expect class Resource(
+    @Language("file-reference") path: String
+) {
     /**
      * The resource path, as provided to the constructor.
      */

--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -2,6 +2,7 @@ package com.goncalossilva.resources
 
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
+import org.intellij.lang.annotations.Language
 import org.w3c.xhr.XMLHttpRequest
 import kotlin.js.definedExternally
 
@@ -19,7 +20,9 @@ private external class TextDecoder(encoding: String = definedExternally) {
  *
  * Workaround inspired by Ktor: https://github.com/ktorio/ktor/blob/b8f18e40baabf9756a16843d6cbd80bff6f006c6/ktor-utils/js/src/io/ktor/util/PlatformUtilsJs.kt#L9-L15
  */
-public actual class Resource actual constructor(public actual val path: String) {
+public actual class Resource actual constructor(
+    @Language("file-reference") public actual val path: String
+) {
     private val resourceBrowser: ResourceBrowser by lazy { ResourceBrowser(path) }
     private val resourceNode: ResourceNode by lazy { ResourceNode(path) }
 

--- a/resources-library/src/jvmMain/kotlin/Resource.kt
+++ b/resources-library/src/jvmMain/kotlin/Resource.kt
@@ -1,8 +1,11 @@
 package com.goncalossilva.resources
 
 import java.io.InputStream
+import org.intellij.lang.annotations.Language
 
-public actual class Resource actual constructor(public actual val path: String) {
+public actual class Resource actual constructor(
+    @Language("file-reference") public actual val path: String
+) {
 
     private val resource
         get() = Resource::class.java.classLoader.getResource(path)

--- a/resources-library/src/posixMain/kotlin/Resource.kt
+++ b/resources-library/src/posixMain/kotlin/Resource.kt
@@ -4,6 +4,7 @@ import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.readBytes
+import org.intellij.lang.annotations.Language
 import platform.posix.F_OK
 import platform.posix.access
 import platform.posix.fclose
@@ -12,7 +13,9 @@ import platform.posix.fread
 import platform.posix.posix_errno
 import platform.posix.strerror
 
-public actual class Resource actual constructor(public actual val path: String) {
+public actual class Resource actual constructor(
+    @Language("file-reference") public actual val path: String
+) {
     public actual fun exists(): Boolean = access(path, F_OK) != -1
 
     public actual fun readText(charset: Charset): String {

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -2,6 +2,7 @@
 
 package com.goncalossilva.resources
 
+import org.intellij.lang.annotations.Language
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.JsAny
 import kotlin.js.JsString
@@ -11,7 +12,9 @@ import kotlin.js.toJsString
  * It's impossible to separate browser/node JS runtimes, as they can't be published separately.
  * See: https://youtrack.jetbrains.com/issue/KT-47038
  */
-public actual class Resource actual constructor(public actual val path: String) {
+public actual class Resource actual constructor(
+    @Language("file-reference") public actual val path: String
+) {
     private val resourceBrowser: ResourceBrowser by lazy { ResourceBrowser(path) }
     private val resourceNode: ResourceNode by lazy { ResourceNode(path) }
 

--- a/resources-library/src/wasmWasiMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmWasiMain/kotlin/Resource.kt
@@ -1,5 +1,6 @@
 package com.goncalossilva.resources
 
+import org.intellij.lang.annotations.Language
 import kotlin.wasm.WasmImport
 import kotlin.wasm.unsafe.MemoryAllocator
 import kotlin.wasm.unsafe.Pointer
@@ -62,7 +63,9 @@ private external fun wasiPathFilestatGet(
 // Buffer size balances memory usage with I/O efficiency for typical resource files.
 private const val BUFFER_SIZE = 8 * 1024
 
-public actual class Resource actual constructor(public actual val path: String) {
+public actual class Resource actual constructor(
+    @Language("file-reference") public actual val path: String
+) {
     public actual fun exists(): Boolean = withScopedMemoryAllocator { allocator ->
         val pathBytes = path.encodeToByteArray()
         val pathPtr = allocator.writeBytes(pathBytes)


### PR DESCRIPTION
Annotate `Resource` path parameters with `@Language("file-reference")` in the common declaration and every platform implementation. Exposes JetBrains Annotations as a multiplatform API dependency so consumers can resolve the annotation.

Closes #64.