### PR TITLE
Fix file-reference injection

### DIFF
--- a/resources-library/src/posixMain/kotlin/Resource.kt
+++ b/resources-library/src/posixMain/kotlin/Resource.kt
@@ -14,7 +14,7 @@ import platform.posix.posix_errno
 import platform.posix.strerror
 
 public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
+    @Language(value = "file-reference", prefix = "/") public actual val path: String
 ) {
     public actual fun exists(): Boolean = access(path, F_OK) != -1
 


### PR DESCRIPTION
Adding a slash fixes IDE highlighting but breaks loading. *Implying* a slash *should* fix the highlighting without breaking the loading.

This change doesn't actually fix the issue but that seems like a bug in Jetbrains' implementation! According to the way this annotation is documented, this *should* work, and that's what matters.