### PR TITLE
Revert IDE completion for resource paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes are documented in this file, whose format follows [Keep a Change
 
 ## [Unreleased]
 
+### Removed
+
+- Remove IDE completion and navigation metadata for resource paths while the approach is reconsidered. ([#317](https://github.com/goncalossilva/kotlinx-resources/pull/317))
+
 ### Fixed
 
 - Fix `wasmWasi` targets missing resources from shared source sets. ([#322](https://github.com/goncalossilva/kotlinx-resources/issues/322))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ android-sdk-compile = "36"
 android-sdk-min = "21"
 androidx-test-core = "1.7.0"
 androidx-test-runner = "1.7.0"
-jetbrains-annotations = "26.1.0"
 useanybrowser = "0.5.0"
 buildconfig = "6.0.10"
 detekt = "1.23.8"
@@ -18,7 +17,6 @@ yarn = "1.22.22"
 [libraries]
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
-jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/resources-library/build.gradle.kts
+++ b/resources-library/build.gradle.kts
@@ -82,11 +82,7 @@ kotlin {
             languageSettings.optIn("kotlinx.cinterop.BetaInteropApi")
         }
 
-        val commonMain by getting {
-            dependencies {
-                api(libs.jetbrains.annotations)
-            }
-        }
+        val commonMain by getting
         val jsMain by getting
         val wasmJsMain by getting
         val wasmWasiMain by getting {

--- a/resources-library/src/androidMain/kotlin/com/goncalossilva/resources/Resource.kt
+++ b/resources-library/src/androidMain/kotlin/com/goncalossilva/resources/Resource.kt
@@ -3,7 +3,6 @@ package com.goncalossilva.resources
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import java.io.IOException
-import org.intellij.lang.annotations.Language
 
 /**
  * Android resource implementation supporting two execution contexts:
@@ -12,9 +11,7 @@ import org.intellij.lang.annotations.Language
  *
  * Assets are tried first (when running in an instrumentation context), falling back to ClassLoader.
  */
-public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
-) {
+public actual class Resource actual constructor(public actual val path: String) {
     /**
      * Normalized path with leading '/' stripped.
      *

--- a/resources-library/src/appleMain/kotlin/Resource.kt
+++ b/resources-library/src/appleMain/kotlin/Resource.kt
@@ -7,7 +7,6 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.readBytes
 import kotlinx.cinterop.value
-import org.intellij.lang.annotations.Language
 import platform.Foundation.NSASCIIStringEncoding
 import platform.Foundation.NSBundle
 import platform.Foundation.NSData
@@ -23,9 +22,7 @@ import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.stringWithContentsOfFile
 
 @OptIn(UnsafeNumber::class)
-public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
-) {
+public actual class Resource actual constructor(public actual val path: String) {
     private val absolutePath = NSBundle.mainBundle.pathForResource(
         path.substringBeforeLast("."),
         path.substringAfterLast(".")

--- a/resources-library/src/commonMain/kotlin/Resource.kt
+++ b/resources-library/src/commonMain/kotlin/Resource.kt
@@ -1,7 +1,5 @@
 package com.goncalossilva.resources
 
-import org.intellij.lang.annotations.Language
-
 /**
  * Provides access to resource on [path].
  *
@@ -9,9 +7,7 @@ import org.intellij.lang.annotations.Language
  * `Resource("some/optional/folders/file.txt")` for a file located at
  * `src/commonTest/resources/some/optional/folders/file.txt`.
  */
-public expect class Resource(
-    @Language("file-reference") path: String
-) {
+public expect class Resource(path: String) {
     /**
      * The resource path, as provided to the constructor.
      */

--- a/resources-library/src/jsMain/kotlin/Resource.kt
+++ b/resources-library/src/jsMain/kotlin/Resource.kt
@@ -2,7 +2,6 @@ package com.goncalossilva.resources
 
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
-import org.intellij.lang.annotations.Language
 import org.w3c.xhr.XMLHttpRequest
 import kotlin.js.definedExternally
 
@@ -20,9 +19,7 @@ private external class TextDecoder(encoding: String = definedExternally) {
  *
  * Workaround inspired by Ktor: https://github.com/ktorio/ktor/blob/b8f18e40baabf9756a16843d6cbd80bff6f006c6/ktor-utils/js/src/io/ktor/util/PlatformUtilsJs.kt#L9-L15
  */
-public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
-) {
+public actual class Resource actual constructor(public actual val path: String) {
     private val resourceBrowser: ResourceBrowser by lazy { ResourceBrowser(path) }
     private val resourceNode: ResourceNode by lazy { ResourceNode(path) }
 

--- a/resources-library/src/jvmMain/kotlin/Resource.kt
+++ b/resources-library/src/jvmMain/kotlin/Resource.kt
@@ -1,11 +1,8 @@
 package com.goncalossilva.resources
 
 import java.io.InputStream
-import org.intellij.lang.annotations.Language
 
-public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
-) {
+public actual class Resource actual constructor(public actual val path: String) {
 
     private val resource
         get() = Resource::class.java.classLoader.getResource(path)

--- a/resources-library/src/posixMain/kotlin/Resource.kt
+++ b/resources-library/src/posixMain/kotlin/Resource.kt
@@ -4,7 +4,6 @@ import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.readBytes
-import org.intellij.lang.annotations.Language
 import platform.posix.F_OK
 import platform.posix.access
 import platform.posix.fclose
@@ -13,9 +12,7 @@ import platform.posix.fread
 import platform.posix.posix_errno
 import platform.posix.strerror
 
-public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
-) {
+public actual class Resource actual constructor(public actual val path: String) {
     public actual fun exists(): Boolean = access(path, F_OK) != -1
 
     public actual fun readText(charset: Charset): String {

--- a/resources-library/src/wasmJsMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmJsMain/kotlin/Resource.kt
@@ -2,7 +2,6 @@
 
 package com.goncalossilva.resources
 
-import org.intellij.lang.annotations.Language
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.JsAny
 import kotlin.js.JsString
@@ -12,9 +11,7 @@ import kotlin.js.toJsString
  * It's impossible to separate browser/node JS runtimes, as they can't be published separately.
  * See: https://youtrack.jetbrains.com/issue/KT-47038
  */
-public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
-) {
+public actual class Resource actual constructor(public actual val path: String) {
     private val resourceBrowser: ResourceBrowser by lazy { ResourceBrowser(path) }
     private val resourceNode: ResourceNode by lazy { ResourceNode(path) }
 

--- a/resources-library/src/wasmWasiMain/kotlin/Resource.kt
+++ b/resources-library/src/wasmWasiMain/kotlin/Resource.kt
@@ -1,6 +1,5 @@
 package com.goncalossilva.resources
 
-import org.intellij.lang.annotations.Language
 import kotlin.wasm.WasmImport
 import kotlin.wasm.unsafe.MemoryAllocator
 import kotlin.wasm.unsafe.Pointer
@@ -63,9 +62,7 @@ private external fun wasiPathFilestatGet(
 // Buffer size balances memory usage with I/O efficiency for typical resource files.
 private const val BUFFER_SIZE = 8 * 1024
 
-public actual class Resource actual constructor(
-    @Language("file-reference") public actual val path: String
-) {
+public actual class Resource actual constructor(public actual val path: String) {
     public actual fun exists(): Boolean = withScopedMemoryAllocator { allocator ->
         val pathBytes = path.encodeToByteArray()
         val pathPtr = allocator.writeBytes(pathBytes)


### PR DESCRIPTION
Reverts the IDE completion and navigation metadata added in #317 while the approach is reconsidered following the discussion in #318.

`Resource("images/logo.png")` means “relative to a resource root,” but that root can differ by platform: a classloader on JVM, an asset or classloader on Android, a bundle on Apple platforms, and filesystem or packaged-resource mechanisms elsewhere. `file-reference` tells IntelliJ that the string is a file path, but not what it is relative to. Adding `/` may help its generic resolver, but there is no guarantee that the resolver root matches the library resource root.

Meaning, this is a deeper mismatch of concepts rather than IntelliJ merely ignoring `prefix`. Before changing all platform declarations, it would be useful to confirm IntelliJ's intended resolution behavior and whether `file-reference` can express this API's semantics.